### PR TITLE
allow sync iterators

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,11 @@ Async-Transformers is a tiny no-frills no-dependencies ts-first implementation o
 
 The method `asyncBufferedTransformer()` was inspired by [rust futures `buffered()`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.buffered).
 
-## Example
+## Usage
+
+```bash
+npm add @understand-ai/async-transformer
+```
 
 Here's an example that downloads all status code images from [http.cat](https://http.cat), but only 7 at a time to be a good
 internet citizen.
@@ -106,6 +110,6 @@ await drainStream(asyncBufferedTransformer(yourAsyncGenerator(inputStream), {
 
 //will resolve with all outputs in-order
 const results = await collectAll(asyncBufferedTransformer(yourAsyncGenerator(inputStream), {
-    noOfParallelExecutions:
+    noOfParallelExecutions
 }))
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ async function* streamAllHttpCats(): AsyncIterable<
 }
 
 const main = async () => {
-  // must be >= 2 for the parallel execution to make sense (otherwise throws an Error)
+  // if numberOfParallelExecutions === 0 || numberOfParallelExecutions === 1 we just serially execute
   const numberOfParallelExecutions = 7;
   for await (const { status, responseStatus, body } of asyncBufferedTransformer(
     streamAllHttpCats(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understand-ai/async-transformer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understand-ai/async-transformer",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/node18": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@understand-ai/async-transformer",
-  "version": "1.0.1",
-  "description": "concurrent processing of async iterators",
+  "version": "1.1.0",
+  "description": "concurrent processing of iterators",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/asyncBufferedTransformer.ts
+++ b/src/asyncBufferedTransformer.ts
@@ -35,11 +35,10 @@ export async function* asyncBufferedTransformer<T>(
 
   if (numberOfParallelExecutions === 0 || numberOfParallelExecutions === 1) {
     for await (const wrapper of stream) {
-      yield await wrapper.promise
+      yield await wrapper.promise;
     }
     return;
   }
-
 
   const bufferSize = numberOfParallelExecutions - 1;
   const buffer: (PromiseWrapper<T> | undefined)[] = new Array(bufferSize);

--- a/src/asyncBufferedTransformer.ts
+++ b/src/asyncBufferedTransformer.ts
@@ -27,11 +27,19 @@ export async function* asyncBufferedTransformer<T>(
   { numberOfParallelExecutions }: AsyncBufferedTransformerOptions,
   errorLogger: (message: string, ...params: any) => void = console.log
 ): AsyncIterable<T> {
-  if (numberOfParallelExecutions < 2) {
+  if (numberOfParallelExecutions < 0) {
     throw new Error(
-      "numberOfParallelExecutions, otherwise there is no parallel execution"
+      `numberOfParallelExecutions was ${numberOfParallelExecutions}, expected >= 0`
     );
   }
+
+  if (numberOfParallelExecutions === 0 || numberOfParallelExecutions === 1) {
+    for await (const wrapper of stream) {
+      yield await wrapper.promise
+    }
+    return;
+  }
+
 
   const bufferSize = numberOfParallelExecutions - 1;
   const buffer: (PromiseWrapper<T> | undefined)[] = new Array(bufferSize);

--- a/src/asyncBufferedTransformer.ts
+++ b/src/asyncBufferedTransformer.ts
@@ -23,7 +23,7 @@ export type AsyncBufferedTransformerOptions = {
 };
 
 export async function* asyncBufferedTransformer<T>(
-  stream: AsyncIterable<PromiseWrapper<T>>,
+  stream: Iterable<PromiseWrapper<T>> | AsyncIterable<PromiseWrapper<T>>,
   { numberOfParallelExecutions }: AsyncBufferedTransformerOptions,
   errorLogger: (message: string, ...params: any) => void = console.log
 ): AsyncIterable<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,5 @@ export {
   asyncBufferedTransformer,
   PromiseWrapper,
   collectAll,
+  drainStream
 } from "./asyncBufferedTransformer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,5 @@ export {
   asyncBufferedTransformer,
   PromiseWrapper,
   collectAll,
-  drainStream
+  drainStream,
 } from "./asyncBufferedTransformer";

--- a/tests/asyncBufferedTransformer.spec.ts
+++ b/tests/asyncBufferedTransformer.spec.ts
@@ -196,8 +196,6 @@ describe("asyncBufferedTransformer", () => {
     );
   });
 
-
-
   it.each([
     0,
     1,


### PR DESCRIPTION
There is no reason the transformer shouldn't be able to also transform a sync iterable to an async concurrently processed iterator.