### PR TITLE
Sync iterators in helper methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-ai/async-transformer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "concurrent processing of iterators",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,5 +50,6 @@
   "homepage": "https://github.com/understand-ai/async-transformers#readme",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,5 @@
   "homepage": "https://github.com/understand-ai/async-transformers#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
+  }
 }

--- a/src/asyncBufferedTransformer.ts
+++ b/src/asyncBufferedTransformer.ts
@@ -93,7 +93,7 @@ export async function* asyncBufferedTransformer<T>(
 }
 
 export const drainStream = async <T>(
-  streamToDrain: AsyncIterable<T>
+  streamToDrain: AsyncIterable<T> | Iterable<T>
 ): Promise<void> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for await (const _ of streamToDrain) {
@@ -104,7 +104,7 @@ export const drainStream = async <T>(
 };
 
 export const collectAll = async <T>(
-  streamToCollect: AsyncIterable<T>
+  streamToCollect: AsyncIterable<T> | Iterable<T>
 ): Promise<T[]> => {
   const results = [];
   for await (const output of streamToCollect) {

--- a/tests/asyncBufferedTransformer.spec.ts
+++ b/tests/asyncBufferedTransformer.spec.ts
@@ -489,4 +489,15 @@ describe("asyncBufferedTransformer", () => {
       )
     ).rejects.toBeTruthy();
   });
+
+  it("can collect / drain an iterable as well", async () => {
+    const iterable = function* (): Iterable<string> {
+      yield "something";
+    };
+
+    const collected = await collectAll(iterable());
+
+    expect(collected).toEqual(["something"]);
+    await expect(drainStream(iterable())).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
helper methods should also allow non-async iterables just like the main method.